### PR TITLE
animato 1.2.6

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 // Dependencies
-var Raf = require("raf");
+var Raf = require("raf")
+  , typpy = require("typpy")
+  ;
 
 /**
  * Animato
@@ -37,9 +39,11 @@ function Animato(from, to, time, step, complete) {
     if (arguments.length === 1 && from && typeof from.from === "object" && typeof from.to === "object") {
         return new Animato(from.from, from.to, from.duration, from.step, from.complete);
     }
-    if (this.constructor !== Animato) {
+
+    if (!typpy(this, Animato)) {
         return new Animato(from, to, time, step, complete);
     }
+
     this._from = from;
     this._inter = {};
     this._to = to || null;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "homepage": "https://github.com/IonicaBizau/animato.js#readme",
   "dependencies": {
-    "raf": "^3.1.0"
+    "raf": "^3.1.0",
+    "typpy": "^2.3.3"
   },
   "devDependencies": {},
   "blah": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "animato",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Simple way to animate anything (even simple values).",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Fix a bug that appears in strict mode.

`this` is undefined when not calling the function using `new`, so use `typpy` to check if the context is a current instance, otherwise, create one. :boom:
